### PR TITLE
Split Width Threshold: Handle nil value

### DIFF
--- a/dired-preview.el
+++ b/dired-preview.el
@@ -322,7 +322,8 @@ checked against `split-width-threshold' or
 
 (defun dired-preview-display-action-side ()
   "Pick a side window that is appropriate for the given frame."
-  (if-let ((width (window-body-width))
+  (if-let (split-width-threshold
+	   (width (window-body-width))
            ((>= width (window-body-height)))
            ((>= width split-width-threshold)))
       `(:side right :dimension window-width :size ,(dired-preview-get-window-size :width))


### PR DESCRIPTION
Fixes 
```
Debugger entered--Lisp error: (wrong-type-argument number-or-marker-p nil)
  >=(238 nil)
  (and s (>= width split-width-threshold))
  (let* ((width (and t (window-body-width))) (s (and width (>= width (window-body-height)))) (s (and s (>= width split-width-threshold)))) (if s (list ':side 'right ':dimension 'window-width ':size (dired-preview-get-window-size :width)) (list ':side 'bottom ':dimension 'window-height ':size (dired-preview-get-window-size :height))))
  dired-preview-display-action-side()
```
I disabled horizontal splitting on my Emacs setup via

```elisp
(custom-set-variables
 '(split-width-threshold nil))
```