### PR TITLE
Temporarily bind recentf-track-opened-file to #'ignore

### DIFF
--- a/dired-preview.el
+++ b/dired-preview.el
@@ -251,7 +251,7 @@ FILE."
 ;; that returns the method with its implementation?
 (cl-defmethod dired-preview--get-buffer ((file (head text)))
   "Get preview buffer for text FILE type."
-  (cl-letf (((symbol-function 'recentf-track-closed-file) #'ignore))
+  (cl-letf (((symbol-function 'recentf-track-opened-file) #'ignore))
     (let ((file (cdr file))
           (inhibit-message t)
           (enable-dir-local-variables nil)


### PR DESCRIPTION
Prevents adding previewed files to recentf-list.

recentf-track-closed-file is the wrong handler: This function is used to remove unwanted (e.g. non-readable) files from recentf-list.

Refs #5