### PR TITLE
Allow ignoring of files without extensions

### DIFF
--- a/dired-preview-test.el
+++ b/dired-preview-test.el
@@ -1,0 +1,40 @@
+;;; dired-preview-test.el --- Unit tests for Dired preview -*- lexical-binding: t -*-
+
+;;; Commentary:
+
+;; Tests for Dired preview.
+
+;;; Code:
+
+(require 'ert)
+(require 'dired-preview)
+
+(ert-deftest dired-preview-test--dired-preview--file-ignored-p ()
+  "Test that `dired-preview--file-ignored-p' returns non-nil for ignored file names."
+  (let ((dired-preview-ignored-extensions-regexp
+         (custom--standard-value 'dired-preview-ignored-extensions-regexp)))
+    (dolist (ext '("mkv" "webm" "mp4" "mp3" "ogg" "m4a" "flac" "wav"
+                   "gz" "zst" "tar" "xz" "rar" "zip" "iso" "epub" "pdf"))
+      (should (dired-preview--file-ignored-p (format "example.%s" ext)))
+      (should-not (dired-preview--file-ignored-p (format "example.%s_" ext)))))
+  (let ((dired-preview-ignored-extensions-regexp "\\.DS_Store\\'"))
+    (should (dired-preview--file-ignored-p ".DS_Store"))))
+
+(ert-deftest dired-preview-test--dired-preview--infer-type ()
+  "Test that `dired-preview--infer-type' infers the correct file type."
+  (let ((dired-preview-ignored-extensions-regexp
+         (custom--standard-value 'dired-preview-ignored-extensions-regexp)))
+    (dolist (ext '("mkv" "webm" "mp4" "mp3" "ogg" "m4a" "flac" "wav"
+                   "gz" "zst" "tar" "xz" "rar" "zip" "iso" "epub" "pdf"))
+      (should (eq 'ignore
+                  (car (dired-preview--infer-type
+                        (format "example.%s" ext)))))
+      (should-not (eq 'ignore
+                      (car (dired-preview--infer-type
+                            (format "example.%s_" ext)))))))
+  (let ((dired-preview-ignored-extensions-regexp "\\.DS_Store\\'"))
+    (should (eq 'ignore
+                (car (dired-preview--infer-type ".DS_Store"))))))
+
+(provide 'dired-preview-test)
+;;; dired-preview-test.el ends here


### PR DESCRIPTION
This change is intended to satisfy #25.

It also adds some unit tests and fixes a couple other bugs:

1. It adds an end-of-string matcher to the `dired-preview-ignored-extensions-regexp`.
2. It corrects the order of arguments to `string-match-p` in a few places.

Also, it makes a change to `dired-preview--large-file-p`. I'm not sure if this can be considered a bug in actual usage, but it made it easier to write the unit tests.

I wasn't sure exactly what to put in the header commentary for the unit tests file, so please give that some attention.

I hope this change will be welcome, and please let me know if you have any feedback.

Thanks!